### PR TITLE
added class and if check for unchanged stocks 

### DIFF
--- a/stocks.css
+++ b/stocks.css
@@ -19,3 +19,8 @@
 {
     color: green;
 }
+
+.unchanged
+{
+    color: grey;
+}

--- a/stocks.js
+++ b/stocks.js
@@ -46,7 +46,9 @@ Module.register("stocks", {
                 priceElement.innerHTML = lastPrice;
 
                 var changeElement = document.createElement("span");
-                if (changePercentage > 0)
+                if(changePercentage == 0)
+                    changeElement.className = "unchanged";
+                else if (changePercentage > 0)
                     changeElement.className = "up";
                 else 
                     changeElement.className = "down";


### PR DESCRIPTION
I added a new class for stocks that are unchanged. This class makes the 0 grey instead of red. Seeing a stock ribbon with a bunch of red zeros can be scary. I have included an image from thinkorswim’s iPhone app showing /ZT[M8] the 2-year treasury bond futures unchanged and the 0’s are white. Since the ticker symbols are already white I thought grey would be a good choice. 

Any stock could be unchanged randomly throughout the day even though it is unlikely. In the morning before the market opens the API is showing a number of the stocks at 0. This is when I first saw all of the red zeros and then looked at the code. 


The first photo is the example photo from thinkorswim’s iPhone app the second is the version of stock ribbon with grey zero on TBT. 

https://imgur.com/a/Ecosh